### PR TITLE
chore: dynamic CLI version + bump to 0.1.1-beta.2

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import chalk from 'chalk';
 import { Command } from 'commander';
 import { authCommand } from './commands/auth.js';
@@ -16,7 +19,11 @@ import { startMcpServer } from './mcp/server.js';
 import { formatPresetsHelp, getPresetNames } from './presets/index.js';
 import { runIdeaMode, runWizard } from './wizard/index.js';
 
-const VERSION = '0.1.0';
+// Read version from package.json dynamically
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageJson = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
+const VERSION = packageJson.version;
 
 const program = new Command();
 


### PR DESCRIPTION
## Summary

Updates the CLI to read its version from `package.json` dynamically and bumps to `0.1.1-beta.2`.

### Changes

1. **Dynamic version reading** - CLI now reads version from `package.json` at runtime instead of hardcoded value
2. **Version bump** - `0.1.1-beta.1` → `0.1.1-beta.2`

### Problem

Previously, the version was hardcoded in `src/cli.ts`:
```typescript
const VERSION = '0.1.0';
```

This required manual updates whenever the version was bumped, leading to version mismatches.

### Solution

Now reads the version dynamically:
```typescript
const packageJson = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
const VERSION = packageJson.version;
```

### Benefits

- Version stays in sync automatically
- Single source of truth (`package.json`)
- No more forgotten version updates

## Test plan

- [x] `ralph-starter --version` returns `0.1.1-beta.2`
- [x] Banner displays correct version
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)