### PR TITLE
fix: always use smart iteration calculation instead of hardcoded default

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,7 +55,7 @@ program
   .option('--validate', 'Run tests/lint/build after each iteration (backpressure)')
   .option('--docker', 'Run in Docker sandbox (coming soon)')
   .option('--prd <file>', 'Read tasks from a PRD markdown file')
-  .option('--max-iterations <n>', 'Maximum loop iterations', '50')
+  .option('--max-iterations <n>', 'Maximum loop iterations (auto-calculated if not specified)')
   .option('--agent <name>', 'Specify agent (claude-code, cursor, codex, opencode)')
   .option('--from <source>', 'Fetch spec from source (file, url, github, todoist, linear, notion)')
   .option('--project <name>', 'Project/repo name for --from integrations')

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -382,17 +382,15 @@ Focus on one task at a time. After completing a task, update IMPLEMENTATION_PLAN
     ? 'Ralph: Implementation from plan'
     : `Ralph: ${finalTask.slice(0, 50)}`;
 
-  // Calculate smart iterations based on tasks (if in build mode and no explicit override)
-  let smartIterations = 10; // default
-  if (isBuildMode && !options.maxIterations && !preset?.maxIterations) {
-    const { iterations, taskCount, reason } = calculateOptimalIterations(cwd);
-    smartIterations = iterations;
+  // Calculate smart iterations based on tasks (always, unless explicitly overridden)
+  const { iterations: smartIterations, taskCount, reason } = calculateOptimalIterations(cwd);
+  if (!options.maxIterations && !preset?.maxIterations) {
     if (taskCount.total > 0) {
       console.log(
         chalk.dim(`Tasks: ${taskCount.pending} pending, ${taskCount.completed} completed`)
       );
-      console.log(chalk.dim(`Max iterations: ${iterations} (${reason})`));
     }
+    console.log(chalk.dim(`Max iterations: ${smartIterations} (${reason})`));
   }
 
   // Apply preset values with CLI overrides

--- a/src/mcp/core/run.ts
+++ b/src/mcp/core/run.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { detectBestAgent } from '../../loop/agents.js';
 import { type LoopOptions, runLoop } from '../../loop/executor.js';
+import { calculateOptimalIterations } from '../../loop/task-counter.js';
 import { fetchFromSource } from '../../sources/index.js';
 
 export interface RunCoreOptions {
@@ -120,11 +121,14 @@ Focus on one task at a time. After completing a task, update IMPLEMENTATION_PLAN
       ? 'Ralph: Implementation from plan'
       : `Ralph: ${finalTask.slice(0, 50)}`;
 
+    // Calculate smart iterations based on tasks
+    const { iterations: smartIterations } = calculateOptimalIterations(cwd);
+
     const loopOptions: LoopOptions = {
       task: finalTask,
       cwd,
       agent,
-      maxIterations: options.maxIterations || 50,
+      maxIterations: options.maxIterations ?? smartIterations,
       auto: options.auto,
       commit: options.commit,
       push: options.push,


### PR DESCRIPTION
## Summary
- Remove hardcoded `'50'` default from `--max-iterations` CLI option
- Always calculate optimal iterations using `calculateOptimalIterations()` based on IMPLEMENTATION_PLAN.md tasks
- Apply smart iteration calculation to all modes (including `--from github`), not just Ralph Playbook mode

## Problem
When running `ralph-starter run --from github --issue X`, it would always show "Loop 1/50" because:
1. The CLI had a hardcoded default of `'50'` for `--max-iterations`
2. Smart iteration calculation was gated behind `isBuildMode` which only triggers for Ralph Playbook mode

## Solution
- CLI option now has no default value: `--max-iterations <n>` (auto-calculated if not specified)
- Smart iteration is always calculated via `calculateOptimalIterations(cwd)`
- Explicit `--max-iterations` flag still takes precedence when provided

## Test plan
- [ ] Run `ralph-starter run --from github --issue <n>` and verify it shows calculated iterations instead of 50
- [ ] Run with explicit `--max-iterations 5` and verify it uses 5
- [ ] Run in Ralph Playbook mode and verify task-based iteration calculation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)