### PR TITLE
fix(ci): trigger auto-label on PR open/sync events

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -2,7 +2,7 @@ name: Prepare Release
 
 on:
   pull_request:
-    types: [labeled, closed]
+    types: [opened, synchronize, labeled, closed]
     branches:
       - main
 


### PR DESCRIPTION
## Summary
- Add `opened` and `synchronize` event triggers to the prepare-release workflow
- This allows the auto-label job to actually run and add `candidate-release` label to PRs with `src/` changes

## Problem
The `auto-label` job in `prepare-release.yml` was never running because:
- Workflow only triggered on `labeled` and `closed` events
- But the auto-label job condition excluded those events (`github.event.action != 'labeled' && github.event.action != 'closed'`)

## Solution
Add `opened` and `synchronize` to the trigger types so the auto-label job runs when PRs are created or updated.

## Test plan
- [ ] Create a PR with `src/` file changes and verify `candidate-release` label is automatically added

🤖 Generated with [Claude Code](https://claude.com/claude-code)