### PR TITLE
fix(ci): add missing permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
+  issues: write
 
 jobs:
   release:


### PR DESCRIPTION
## Summary
Add missing permissions to `release.yml` so it can comment on PRs after publishing.

## Problem
The "Comment on PR" step was failing with:
```
Resource not accessible by integration
```

## Solution
Add `pull-requests: write` and `issues: write` permissions to the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)