### PR TITLE
feat: add auto mode for batch task processing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import chalk from 'chalk';
 import { Command } from 'commander';
 import { authCommand } from './commands/auth.js';
+import { autoCommand } from './commands/auto.js';
 import { checkCommand } from './commands/check.js';
 import { configCommand } from './commands/config.js';
 import { initCommand } from './commands/init.js';
@@ -206,6 +207,40 @@ program
   .description('Start as an MCP (Model Context Protocol) server for Claude Desktop/Code')
   .action(async () => {
     await startMcpServer();
+  });
+
+// ralph-starter auto - Autonomous batch task processing
+program
+  .command('auto')
+  .description('Run in autonomous mode, processing multiple tasks from GitHub/Linear')
+  .requiredOption('--source <source>', 'Source to fetch tasks from (github, linear)')
+  .option('--project <name>', 'Project identifier (owner/repo for GitHub)')
+  .option('--label <name>', 'Filter tasks by label (e.g., "auto-ready")')
+  .option('--limit <n>', 'Maximum tasks to process (default: 10)', '10')
+  .option('--dry-run', 'Preview mode - show tasks without executing')
+  .option('--analyze', 'Analyze codebase before processing')
+  .option('--generate-docs', 'Generate documentation for changed files')
+  .option('--propose-ideas', 'Propose improvements based on analysis')
+  .option('--skip-pr', 'Skip PR creation (commit only)')
+  .option('--agent <name>', 'Specify agent to use')
+  .option('--validate', 'Run validation after each task', true)
+  .option('--no-validate', 'Skip validation')
+  .option('--max-iterations <n>', 'Max iterations per task (default: 15)')
+  .action(async (options) => {
+    await autoCommand({
+      source: options.source,
+      project: options.project,
+      label: options.label,
+      limit: parseInt(options.limit, 10),
+      dryRun: options.dryRun,
+      analyze: options.analyze,
+      generateDocs: options.generateDocs,
+      proposeIdeas: options.proposeIdeas,
+      skipPr: options.skipPr,
+      agent: options.agent,
+      validate: options.validate,
+      maxIterations: options.maxIterations ? parseInt(options.maxIterations, 10) : undefined,
+    });
   });
 
 // ralph-starter presets - List available workflow presets

--- a/src/commands/auto.ts
+++ b/src/commands/auto.ts
@@ -1,0 +1,217 @@
+/**
+ * Auto Mode Command
+ *
+ * Runs ralph-starter in fully autonomous mode, processing multiple tasks
+ * from GitHub/Linear with automatic commits and PRs.
+ */
+
+import chalk from 'chalk';
+import ora from 'ora';
+import { hasUncommittedChanges, isGitRepo } from '../automation/git.js';
+import { detectBestAgent } from '../loop/agents.js';
+import { type BatchTask, completeTask, fetchBatchTasks } from '../loop/batch-fetcher.js';
+import { executeTaskBatch } from '../loop/task-executor.js';
+
+export interface AutoModeOptions {
+  /** Source to fetch tasks from */
+  source: 'github' | 'linear';
+  /** Project identifier (owner/repo for GitHub, project name for Linear) */
+  project?: string;
+  /** Filter tasks by label */
+  label?: string;
+  /** Maximum number of tasks to process */
+  limit?: number;
+  /** Preview mode - don't execute, just show what would be done */
+  dryRun?: boolean;
+  /** Analyze codebase before processing */
+  analyze?: boolean;
+  /** Generate documentation for changed files */
+  generateDocs?: boolean;
+  /** Propose improvements based on analysis */
+  proposeIdeas?: boolean;
+  /** Skip PR creation (commit only) */
+  skipPr?: boolean;
+  /** Agent to use */
+  agent?: string;
+  /** Run validation after each task */
+  validate?: boolean;
+  /** Max iterations per task */
+  maxIterations?: number;
+}
+
+/**
+ * Main auto mode command
+ */
+export async function autoCommand(options: AutoModeOptions): Promise<void> {
+  const cwd = process.cwd();
+  const spinner = ora();
+
+  console.log();
+  console.log(chalk.cyan.bold('ralph-starter auto'));
+  console.log(chalk.dim('Autonomous batch task processing'));
+  console.log();
+
+  // Validate git repo
+  if (!(await isGitRepo(cwd))) {
+    console.log(chalk.red('Error: Not a git repository'));
+    console.log(chalk.dim('Run this command in a git repository'));
+    process.exit(1);
+  }
+
+  // Check for uncommitted changes
+  if (await hasUncommittedChanges(cwd)) {
+    console.log(chalk.yellow('Warning: You have uncommitted changes'));
+    console.log(chalk.dim('Consider committing or stashing them before running auto mode'));
+    console.log();
+  }
+
+  // Validate source
+  if (!options.source) {
+    console.log(chalk.red('Error: --source is required'));
+    console.log(chalk.dim('Use --source github or --source linear'));
+    process.exit(1);
+  }
+
+  // Validate project for sources that need it
+  if (!options.project && options.source !== 'linear') {
+    console.log(chalk.red('Error: --project is required for GitHub source'));
+    console.log(chalk.dim('Use --project owner/repo'));
+    process.exit(1);
+  }
+
+  // Detect agent
+  spinner.start('Detecting available agent...');
+  const agent = await detectBestAgent();
+  if (!agent) {
+    spinner.fail('No coding agent found');
+    console.log(chalk.dim('Install Claude Code: npm i -g @anthropic-ai/claude-code'));
+    process.exit(1);
+  }
+  spinner.succeed(`Using agent: ${chalk.cyan(agent.name)}`);
+
+  // Fetch tasks
+  spinner.start(`Fetching tasks from ${options.source}...`);
+  let tasks: BatchTask[];
+  try {
+    tasks = await fetchBatchTasks({
+      source: options.source,
+      project: options.project,
+      label: options.label,
+      limit: options.limit || 10,
+    });
+  } catch (error) {
+    spinner.fail(
+      `Failed to fetch tasks: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
+    process.exit(1);
+  }
+
+  if (tasks.length === 0) {
+    spinner.succeed('No tasks found matching criteria');
+    console.log();
+    console.log(chalk.dim('Try adjusting your filters:'));
+    console.log(chalk.dim('  --label <name>  Filter by label'));
+    console.log(chalk.dim('  --limit <n>     Increase task limit'));
+    return;
+  }
+
+  spinner.succeed(`Found ${chalk.cyan(tasks.length)} tasks`);
+  console.log();
+
+  // Display tasks
+  console.log(chalk.bold('Tasks to process:'));
+  console.log();
+  for (let i = 0; i < tasks.length; i++) {
+    const task = tasks[i];
+    const labels = task.labels?.length ? chalk.dim(` [${task.labels.join(', ')}]`) : '';
+    console.log(`  ${chalk.cyan(`${i + 1}.`)} ${task.title}${labels}`);
+    console.log(chalk.dim(`     ${task.url}`));
+  }
+  console.log();
+
+  // Dry run mode
+  if (options.dryRun) {
+    console.log(chalk.yellow('Dry run mode - no changes will be made'));
+    console.log();
+    console.log(chalk.dim('Would execute:'));
+    for (const task of tasks) {
+      console.log(chalk.dim(`  - Create branch: auto/${task.id}`));
+      console.log(chalk.dim(`  - Run agent with task: "${task.title}"`));
+      console.log(chalk.dim(`  - Commit changes`));
+      if (!options.skipPr) {
+        console.log(chalk.dim(`  - Create PR`));
+      }
+    }
+    return;
+  }
+
+  // Execute tasks
+  console.log(chalk.bold('Starting batch execution...'));
+  console.log();
+
+  const results = await executeTaskBatch({
+    tasks,
+    cwd,
+    agent,
+    auto: true,
+    commit: true,
+    push: true,
+    pr: !options.skipPr,
+    validate: options.validate ?? true,
+    maxIterations: options.maxIterations,
+    onTaskStart: (task, index) => {
+      console.log();
+      console.log(chalk.cyan.bold(`Task ${index + 1}/${tasks.length}: ${task.title}`));
+      console.log(chalk.dim(`Source: ${task.url}`));
+      console.log();
+    },
+    onTaskComplete: async (task, result, index) => {
+      console.log();
+      if (result.success) {
+        console.log(chalk.green(`Task ${index + 1} completed successfully`));
+        if (result.prUrl) {
+          console.log(chalk.dim(`PR: ${result.prUrl}`));
+        }
+        // Mark task as complete in source
+        try {
+          await completeTask(task, result);
+        } catch (error) {
+          console.log(
+            chalk.yellow(
+              `Warning: Could not mark task as complete: ${error instanceof Error ? error.message : 'Unknown error'}`
+            )
+          );
+        }
+      } else {
+        console.log(chalk.red(`Task ${index + 1} failed: ${result.error}`));
+      }
+    },
+    onTaskFail: (_task, error, index) => {
+      console.log();
+      console.log(chalk.red(`Task ${index + 1} error: ${error.message}`));
+    },
+  });
+
+  // Summary
+  console.log();
+  console.log(chalk.bold('Batch execution complete'));
+  console.log();
+
+  const successful = results.filter((r) => r.success).length;
+  const failed = results.filter((r) => !r.success).length;
+
+  console.log(`  ${chalk.green('Successful:')} ${successful}`);
+  console.log(`  ${chalk.red('Failed:')} ${failed}`);
+
+  if (results.some((r) => r.prUrl)) {
+    console.log();
+    console.log(chalk.bold('Pull Requests:'));
+    for (const result of results) {
+      if (result.prUrl) {
+        console.log(`  ${chalk.cyan(result.prUrl)}`);
+      }
+    }
+  }
+
+  console.log();
+}

--- a/src/loop/batch-fetcher.ts
+++ b/src/loop/batch-fetcher.ts
@@ -1,0 +1,263 @@
+/**
+ * Batch Task Fetcher
+ *
+ * Fetches multiple tasks from GitHub/Linear for batch processing.
+ */
+
+import { execa } from 'execa';
+
+/**
+ * A task to be processed in auto mode
+ */
+export interface BatchTask {
+  /** Unique identifier (issue number, ticket ID) */
+  id: string;
+  /** Task title */
+  title: string;
+  /** Full task description */
+  description: string;
+  /** Source integration */
+  source: 'github' | 'linear';
+  /** URL to the task */
+  url: string;
+  /** Priority (lower = higher priority) */
+  priority?: number;
+  /** Labels/tags */
+  labels?: string[];
+  /** Owner/repo for GitHub */
+  project?: string;
+}
+
+/**
+ * Options for fetching batch tasks
+ */
+export interface BatchFetchOptions {
+  /** Source to fetch from */
+  source: 'github' | 'linear';
+  /** Project identifier */
+  project?: string;
+  /** Filter by label */
+  label?: string;
+  /** Maximum tasks to fetch */
+  limit?: number;
+  /** Status filter */
+  status?: string;
+}
+
+/**
+ * Fetch multiple tasks from a source
+ */
+export async function fetchBatchTasks(options: BatchFetchOptions): Promise<BatchTask[]> {
+  switch (options.source) {
+    case 'github':
+      return fetchGitHubTasks(options);
+    case 'linear':
+      return fetchLinearTasks(options);
+    default:
+      throw new Error(`Unsupported source: ${options.source}`);
+  }
+}
+
+/**
+ * Fetch tasks from GitHub issues
+ */
+async function fetchGitHubTasks(options: BatchFetchOptions): Promise<BatchTask[]> {
+  if (!options.project) {
+    throw new Error('Project (owner/repo) is required for GitHub');
+  }
+
+  const args = [
+    'issue',
+    'list',
+    '-R',
+    options.project,
+    '--json',
+    'number,title,body,labels,state,url',
+    '--state',
+    options.status || 'open',
+    '--limit',
+    String(options.limit || 10),
+  ];
+
+  if (options.label) {
+    args.push('--label', options.label);
+  }
+
+  const result = await execa('gh', args);
+  const issues = JSON.parse(result.stdout) as Array<{
+    number: number;
+    title: string;
+    body?: string;
+    labels?: Array<{ name: string }>;
+    url: string;
+  }>;
+
+  return issues.map((issue) => ({
+    id: String(issue.number),
+    title: issue.title,
+    description: issue.body || '',
+    source: 'github' as const,
+    url: issue.url,
+    labels: issue.labels?.map((l) => l.name),
+    project: options.project,
+  }));
+}
+
+/**
+ * Fetch tasks from Linear
+ */
+async function fetchLinearTasks(options: BatchFetchOptions): Promise<BatchTask[]> {
+  // For now, use the Linear CLI if available
+  // TODO: Add direct API support
+  try {
+    const args = ['issue', 'list', '--format', 'json'];
+
+    if (options.project) {
+      args.push('--project', options.project);
+    }
+
+    if (options.label) {
+      args.push('--label', options.label);
+    }
+
+    const result = await execa('linear', args);
+    const issues = JSON.parse(result.stdout) as Array<{
+      id: string;
+      identifier: string;
+      title: string;
+      description?: string;
+      url: string;
+      priority: number;
+      labels?: Array<{ name: string }>;
+    }>;
+
+    return issues.slice(0, options.limit || 10).map((issue) => ({
+      id: issue.identifier,
+      title: issue.title,
+      description: issue.description || '',
+      source: 'linear' as const,
+      url: issue.url,
+      priority: issue.priority,
+      labels: issue.labels?.map((l) => l.name),
+      project: options.project,
+    }));
+  } catch {
+    throw new Error(
+      'Linear CLI not found or not authenticated. Install: npm i -g @linear/cli && linear auth'
+    );
+  }
+}
+
+/**
+ * Claim a task (mark as in-progress)
+ */
+export async function claimTask(task: BatchTask): Promise<void> {
+  switch (task.source) {
+    case 'github':
+      // Add "in-progress" label or assign to bot
+      if (task.project) {
+        try {
+          await execa('gh', [
+            'issue',
+            'edit',
+            task.id,
+            '-R',
+            task.project,
+            '--add-label',
+            'in-progress',
+          ]);
+        } catch {
+          // Label might not exist, that's ok
+        }
+      }
+      break;
+    case 'linear':
+      // Update status to "In Progress"
+      try {
+        await execa('linear', ['issue', 'update', task.id, '--status', 'In Progress']);
+      } catch {
+        // Status might not exist, that's ok
+      }
+      break;
+  }
+}
+
+/**
+ * Mark a task as complete
+ */
+export async function completeTask(
+  task: BatchTask,
+  result: { success: boolean; prUrl?: string }
+): Promise<void> {
+  switch (task.source) {
+    case 'github':
+      if (task.project && result.success) {
+        try {
+          // Remove in-progress label if it exists
+          await execa('gh', [
+            'issue',
+            'edit',
+            task.id,
+            '-R',
+            task.project,
+            '--remove-label',
+            'in-progress',
+          ]);
+        } catch {
+          // Label might not exist
+        }
+
+        // Add comment with PR link
+        if (result.prUrl) {
+          await execa('gh', [
+            'issue',
+            'comment',
+            task.id,
+            '-R',
+            task.project,
+            '--body',
+            `Automated PR created: ${result.prUrl}\n\n*Generated by ralph-starter auto mode*`,
+          ]);
+        }
+      }
+      break;
+    case 'linear':
+      if (result.success) {
+        try {
+          // Update status to "Done" or link PR
+          await execa('linear', ['issue', 'update', task.id, '--status', 'Done']);
+        } catch {
+          // Status might not exist
+        }
+      }
+      break;
+  }
+}
+
+/**
+ * Skip a task (mark as skipped/blocked)
+ */
+export async function skipTask(task: BatchTask, reason: string): Promise<void> {
+  switch (task.source) {
+    case 'github':
+      if (task.project) {
+        try {
+          await execa('gh', [
+            'issue',
+            'comment',
+            task.id,
+            '-R',
+            task.project,
+            '--body',
+            `Skipped by ralph-starter auto mode: ${reason}`,
+          ]);
+        } catch {
+          // Comment failed, that's ok
+        }
+      }
+      break;
+    case 'linear':
+      // Add comment
+      break;
+  }
+}

--- a/src/loop/task-executor.ts
+++ b/src/loop/task-executor.ts
@@ -1,0 +1,283 @@
+/**
+ * Task Executor
+ *
+ * Executes batch tasks sequentially with git automation.
+ */
+
+import chalk from 'chalk';
+import {
+  createBranch,
+  createPullRequest,
+  getCurrentBranch,
+  gitCommit,
+  gitPush,
+  hasUncommittedChanges,
+} from '../automation/git.js';
+import type { Agent } from './agents.js';
+import { type BatchTask, claimTask } from './batch-fetcher.js';
+import { type LoopOptions, runLoop } from './executor.js';
+
+/**
+ * Result of executing a single task
+ */
+export interface TaskResult {
+  /** Task that was executed */
+  task: BatchTask;
+  /** Whether the task completed successfully */
+  success: boolean;
+  /** Error message if failed */
+  error?: string;
+  /** Branch name used */
+  branch?: string;
+  /** PR URL if created */
+  prUrl?: string;
+  /** Number of iterations used */
+  iterations?: number;
+  /** Cost in USD */
+  cost?: number;
+}
+
+/**
+ * Options for batch execution
+ */
+export interface TaskExecutionOptions {
+  /** Tasks to execute */
+  tasks: BatchTask[];
+  /** Working directory */
+  cwd: string;
+  /** Agent to use */
+  agent: Agent;
+  /** Run in auto mode */
+  auto?: boolean;
+  /** Commit after each task */
+  commit?: boolean;
+  /** Push to remote */
+  push?: boolean;
+  /** Create PR */
+  pr?: boolean;
+  /** Run validation */
+  validate?: boolean;
+  /** Max iterations per task */
+  maxIterations?: number;
+  /** Callback when task starts */
+  onTaskStart?: (task: BatchTask, index: number) => void;
+  /** Callback when task completes */
+  onTaskComplete?: (task: BatchTask, result: TaskResult, index: number) => Promise<void> | void;
+  /** Callback when task fails */
+  onTaskFail?: (task: BatchTask, error: Error, index: number) => void;
+}
+
+/**
+ * Execute tasks sequentially
+ */
+export async function executeTaskBatch(options: TaskExecutionOptions): Promise<TaskResult[]> {
+  const {
+    tasks,
+    cwd,
+    agent,
+    auto = true,
+    commit = true,
+    push = true,
+    pr = true,
+    validate = true,
+    maxIterations,
+    onTaskStart,
+    onTaskComplete,
+    onTaskFail,
+  } = options;
+
+  const results: TaskResult[] = [];
+  const baseBranch = await getCurrentBranch(cwd);
+
+  for (let i = 0; i < tasks.length; i++) {
+    const task = tasks[i];
+    const result: TaskResult = {
+      task,
+      success: false,
+    };
+
+    try {
+      // Notify start
+      onTaskStart?.(task, i);
+
+      // Claim the task
+      await claimTask(task);
+
+      // Create branch for this task
+      const branchName = `auto/${task.source}-${task.id}`;
+      result.branch = branchName;
+
+      try {
+        await createBranch(cwd, branchName);
+      } catch {
+        // Branch might already exist, try to check it out
+        const { execa } = await import('execa');
+        await execa('git', ['checkout', branchName], { cwd });
+      }
+
+      // Build the task prompt
+      const taskPrompt = buildTaskPrompt(task);
+
+      // Run the loop for this task
+      const loopOptions: LoopOptions = {
+        task: taskPrompt,
+        cwd,
+        agent,
+        auto,
+        commit: false, // We handle commits ourselves
+        push: false,
+        pr: false,
+        validate,
+        maxIterations: maxIterations ?? 15,
+        trackProgress: true,
+        trackCost: true,
+      };
+
+      const loopResult = await runLoop(loopOptions);
+
+      result.iterations = loopResult.iterations;
+      // Cost tracking is handled by the loop internally
+
+      // Check if there are changes to commit
+      if (commit && (await hasUncommittedChanges(cwd))) {
+        const commitMessage = buildCommitMessage(task);
+        await gitCommit(cwd, commitMessage);
+
+        if (push) {
+          await gitPush(cwd, branchName);
+
+          if (pr) {
+            // Create PR - returns the PR URL directly
+            const prUrl = await createPullRequest(cwd, {
+              title: `[Auto] ${task.title}`,
+              body: buildPrBody(task, result),
+              base: baseBranch,
+            });
+            result.prUrl = prUrl;
+          }
+        }
+      }
+
+      result.success = true;
+      await onTaskComplete?.(task, result, i);
+    } catch (error) {
+      result.success = false;
+      result.error = error instanceof Error ? error.message : 'Unknown error';
+      onTaskFail?.(task, error instanceof Error ? error : new Error('Unknown error'), i);
+      await onTaskComplete?.(task, result, i);
+    } finally {
+      // Always switch back to base branch
+      try {
+        const { execa } = await import('execa');
+        await execa('git', ['checkout', baseBranch], { cwd });
+      } catch {
+        // Ignore checkout errors
+      }
+    }
+
+    results.push(result);
+  }
+
+  return results;
+}
+
+/**
+ * Build the task prompt for the agent
+ */
+function buildTaskPrompt(task: BatchTask): string {
+  const lines: string[] = [];
+
+  lines.push(`# Task: ${task.title}`);
+  lines.push('');
+  lines.push(`Source: ${task.url}`);
+  lines.push('');
+
+  if (task.labels?.length) {
+    lines.push(`Labels: ${task.labels.join(', ')}`);
+    lines.push('');
+  }
+
+  lines.push('## Description');
+  lines.push('');
+  lines.push(task.description || '*No description provided*');
+  lines.push('');
+  lines.push('## Instructions');
+  lines.push('');
+  lines.push('1. Analyze the task requirements');
+  lines.push('2. Implement the necessary changes');
+  lines.push('3. Ensure tests pass (if applicable)');
+  lines.push('4. Follow existing code patterns');
+  lines.push('');
+  lines.push(
+    'When complete, the changes will be automatically committed and a PR will be created.'
+  );
+
+  return lines.join('\n');
+}
+
+/**
+ * Build commit message for the task
+ */
+function buildCommitMessage(task: BatchTask): string {
+  // Determine commit type from labels or title
+  let type = 'feat';
+  const lowerTitle = task.title.toLowerCase();
+  const labels = task.labels?.map((l) => l.toLowerCase()) || [];
+
+  if (labels.includes('bug') || lowerTitle.includes('fix') || lowerTitle.includes('bug')) {
+    type = 'fix';
+  } else if (labels.includes('docs') || lowerTitle.includes('doc')) {
+    type = 'docs';
+  } else if (labels.includes('refactor') || lowerTitle.includes('refactor')) {
+    type = 'refactor';
+  } else if (labels.includes('test') || lowerTitle.includes('test')) {
+    type = 'test';
+  } else if (labels.includes('chore') || lowerTitle.includes('chore')) {
+    type = 'chore';
+  }
+
+  // Clean up title for commit message
+  const title = task.title
+    .replace(/^\[(feat|fix|docs|refactor|test|chore)\]\s*/i, '')
+    .replace(/^(feat|fix|docs|refactor|test|chore):\s*/i, '')
+    .trim();
+
+  return `${type}: ${title}\n\nCloses ${task.source}#${task.id}\n\nGenerated by ralph-starter auto mode`;
+}
+
+/**
+ * Build PR body
+ */
+function buildPrBody(task: BatchTask, result: TaskResult): string {
+  const lines: string[] = [];
+
+  lines.push('## Summary');
+  lines.push('');
+  lines.push(`Automated implementation for: ${task.url}`);
+  lines.push('');
+
+  if (task.description) {
+    lines.push('## Original Task');
+    lines.push('');
+    lines.push(task.description.slice(0, 500));
+    if (task.description.length > 500) {
+      lines.push('...');
+    }
+    lines.push('');
+  }
+
+  lines.push('## Execution Details');
+  lines.push('');
+  lines.push(`- Iterations: ${result.iterations ?? 'N/A'}`);
+  if (result.cost) {
+    lines.push(`- Estimated cost: $${result.cost.toFixed(4)}`);
+  }
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+  lines.push(
+    '*Generated by [ralph-starter](https://github.com/rubenmarcus/ralph-starter) auto mode*'
+  );
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
Add `ralph-starter auto` command for autonomous batch task processing from GitHub/Linear issues.

## Features
- Batch fetch issues from GitHub/Linear by label
- Sequential task execution with validation gates
- Auto-commit and create PRs per task
- Dry-run mode for previewing tasks
- Task claiming and completion tracking

## New Files
- `src/commands/auto.ts` - Auto mode command
- `src/loop/batch-fetcher.ts` - Batch task fetcher for GitHub/Linear
- `src/loop/task-executor.ts` - Sequential task executor with git automation

## Usage
```bash
# Run auto mode on GitHub issues with 'auto-ready' label
ralph-starter auto --source github --project owner/repo --label auto-ready

# Preview mode - show tasks without executing
ralph-starter auto --source github --project owner/repo --dry-run

# Limit tasks and skip PR creation
ralph-starter auto --source github --project owner/repo --limit 5 --skip-pr
```

## Test Plan
- [x] Build passes
- [x] TypeCheck passes
- [x] Lint passes (new files)
- [x] `ralph-starter auto --help` shows command
- [x] Dry run mode works correctly

## Related
Closes rubenmarcus/ralph-ideas#70

---
Generated with [Claude Code](https://claude.com/claude-code)