### PR TITLE
feat: Anthropic SDK with prompt caching support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.1-beta.15",
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.73.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "chalk": "^5.3.0",
         "chalk-animation": "^2.0.3",
@@ -55,6 +56,26 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.73.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
+      "integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -104,6 +125,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -4993,6 +5023,19 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -6932,6 +6975,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.73.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "chalk": "^5.3.0",
     "chalk-animation": "^2.0.3",
@@ -83,13 +84,13 @@
     "@commitlint/config-conventional": "^20.3.1",
     "@types/inquirer": "^9.0.7",
     "@types/node": "^25.1.0",
+    "@vitest/coverage-v8": "^2.1.8",
     "commitizen": "^4.3.1",
     "cz-conventional-changelog": "^3.3.0",
     "husky": "^9.1.0",
     "lint-staged": "^16.2.7",
     "typescript": "^5.7.3",
-    "vitest": "^2.1.8",
-    "@vitest/coverage-v8": "^2.1.8"
+    "vitest": "^2.1.8"
   },
   "lint-staged": {
     "src/**/*.ts": [


### PR DESCRIPTION
## Summary
- Replaces raw `fetch` calls to Anthropic API with the official `@anthropic-ai/sdk`
- Enables prompt caching via `cache_control: { type: "ephemeral" }` on system messages
- Cache reads are 90% cheaper than regular input tokens
- Adds `system` message field to `LLMRequest` for all providers (Anthropic, OpenAI, OpenRouter)
- Adds cache-aware pricing tiers to cost tracker (write: 1.25x, read: 0.1x)
- Displays cache savings in CLI output and activity.md summaries

## Impact
- Up to 90% reduction in input token costs for repeated system prompts
- Actual API usage metrics instead of text-based estimates (when using Anthropic)
- Singleton client pattern for connection pooling

## Files changed
- `src/llm/api.ts` — Refactored to use Anthropic SDK, added system message + cache support
- `src/loop/cost-tracker.ts` — Added cache pricing, `CacheMetrics`, `recordIterationWithUsage()`
- `package.json` — Added `@anthropic-ai/sdk` dependency

## Test plan
- [x] `npm run build` passes
- [x] `npm run test:run` — all 143 tests pass
- [ ] Call `tryCallLLM()` with system message, verify cache metrics in response
- [ ] Run `ralph-starter run --track-cost` and verify cache savings in cost summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)