### PR TITLE
fix: fix release workflow for pnpm and update scorecard action

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -29,10 +29,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@c5ba7f7862a0f64c1b1a05fbac13e0b8e86ba08c # v4
+
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: '20'
+          cache: 'pnpm'
 
       - name: Determine version bump
         id: bump
@@ -150,7 +154,7 @@ jobs:
           node .github/scripts/update-changelog.cjs "$CLEAN_TITLE"
 
           # Commit changes
-          git add package.json package-lock.json CHANGELOG.md
+          git add package.json pnpm-lock.yaml CHANGELOG.md
           git commit -m "chore(release): bump version to ${NEW_VERSION}"
 
           # Push branch

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -86,7 +86,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@ea651e62978af7915d09fe2e282747c798bf2dab # v2.4.1
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: scorecard-results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary
- **prepare-release.yml**: Add missing `pnpm/action-setup` step and pnpm cache (matching `release.yml`), replace `package-lock.json` with `pnpm-lock.yaml` in `git add` — this was the direct cause of the exit code 128 failure
- **security.yml**: Update `ossf/scorecard-action` from v2.4.1 to v2.4.3 using the correct commit SHA (the previous SHA was the annotated tag object, not the commit, causing "imposter commit" verification failure)

## Test plan
- [ ] Merge a PR with `candidate-release` label to trigger `prepare-release.yml` — verify "Create release branch and PR" step succeeds
- [ ] Verify OSSF Scorecard job passes on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and release workflows for improved package management and dependency tracking.
  * Enhanced security scanning infrastructure with updated tools and processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->