### PR TITLE
fix(security): update codeql-action SHA and harden workflow patterns

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -128,9 +128,10 @@ jobs:
       - name: Calculate new version
         if: steps.collect.outputs.skip != 'true'
         id: version
+        env:
+          CURRENT: ${{ steps.bump.outputs.current }}
+          BUMP: ${{ steps.bump.outputs.bump }}
         run: |
-          CURRENT="${{ steps.bump.outputs.current }}"
-          BUMP="${{ steps.bump.outputs.bump }}"
 
           # Parse version (handle prerelease)
           if [[ "$CURRENT" == *"-"* ]]; then
@@ -295,12 +296,15 @@ jobs:
       - name: Comment on source PR
         if: steps.collect.outputs.skip != 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new }}
+          EXISTING_FOUND: ${{ steps.check.outputs.found }}
         with:
           script: |
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
-            const newVersion = '${{ steps.version.outputs.new }}';
-            const existingFound = '${{ steps.check.outputs.found }}';
+            const newVersion = process.env.NEW_VERSION;
+            const existingFound = process.env.EXISTING_FOUND;
 
             const body = existingFound === 'true'
               ? `Your changes have been added to the existing release PR for **v${newVersion}**.`

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,16 +28,16 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@2d3fe93d4896727350828f23e48f5391e6d3f022 # v3
+        uses: github/codeql-action/init@b5ebac6f4c00c8ccddb7cdcd45fdb248329f808a # v3
         with:
           languages: javascript-typescript
           queries: security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@2d3fe93d4896727350828f23e48f5391e6d3f022 # v3
+        uses: github/codeql-action/autobuild@b5ebac6f4c00c8ccddb7cdcd45fdb248329f808a # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@2d3fe93d4896727350828f23e48f5391e6d3f022 # v3
+        uses: github/codeql-action/analyze@b5ebac6f4c00c8ccddb7cdcd45fdb248329f808a # v3
         with:
           category: "/language:javascript-typescript"
 
@@ -93,6 +93,6 @@ jobs:
           publish_results: true
 
       - name: Upload Scorecard results
-        uses: github/codeql-action/upload-sarif@2d3fe93d4896727350828f23e48f5391e6d3f022 # v3
+        uses: github/codeql-action/upload-sarif@b5ebac6f4c00c8ccddb7cdcd45fdb248329f808a # v3
         with:
           sarif_file: scorecard-results.sarif


### PR DESCRIPTION
## Summary
- Replaced imposter commit SHA (`2d3fe93d`) for `github/codeql-action` with the correct v3 release commit (`b5ebac6f`), fixing the Scorecard SARIF upload failure
- Moved `${{ steps.*.outputs.* }}` interpolations from `run:` blocks to `env:` in `prepare-release.yml` to follow script injection prevention best practices

## Context
The OSSF Scorecard job was failing with:
```
error sending scorecard results to webapp: imposter commit: 2d3fe93d4896727350828f23e48f5391e6d3f022 does not belong to github/codeql-action/upload-sarif
```

This also blocked Scorecard from uploading new scan results, keeping stale Dangerous-Workflow alerts (#79, #80) open. Once this merges and Scorecard re-scans, those stale alerts should auto-close.

## Test plan
- [ ] Verify the Security Scanning workflow passes (especially the OSSF Scorecard job)
- [ ] Verify stale Dangerous-Workflow alerts close after re-scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal release automation infrastructure with improved configuration parameter handling and environment variable management for increased reliability and better maintainability throughout the release pipeline.
  * Updated security analysis tools and dependencies to their latest stable versions, ensuring the most current and effective vulnerability detection capabilities and sustained compliance with industry security best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->