### PR TITLE
chore(release): harden stable release flow

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   release:
     name: Build and Release
+    # `release.yml` already creates tags during automated release PR merges.
+    # Skip this workflow for bot-pushed tags to avoid duplicate publish races.
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ node_modules/
 .ralph/
 config.json
 specs/
+# Local release planning (kept local only)
+specs/RELEASE_PLAN.md
 coverage/
 .nyc_output/
 dist/

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -60,6 +60,22 @@ npm install -g ralph-starter@beta
 npm install -g ralph-starter@0.2.0-beta.1
 ```
 
+## Official Stable Release (from betas)
+
+Use the `Stable Release` GitHub Actions workflow when you want to promote from beta to an official stable release.
+
+1. Go to **Actions → Stable Release → Run workflow**
+2. Set `version` to a stable semver (no prerelease suffix), for example `0.2.0`
+3. Optionally provide curated `release_notes` markdown (or leave empty to auto-consolidate beta changelog entries)
+4. Merge the generated `release/vX.Y.Z` PR into `main`
+5. `Release` workflow creates tag `vX.Y.Z`, publishes GitHub release, and publishes npm with `latest`
+
+### Why this path
+
+- Keeps stable release notes curated from beta iterations
+- Uses the same CI build/test gates as normal releases
+- Avoids manual tagging mistakes
+
 ## Manual Release (Emergency)
 
 If you need to release manually:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "commit": "cz",
-    "build": "tsc",
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
     "dev": "tsc --watch",
     "start": "node dist/cli.js",
     "test": "vitest",


### PR DESCRIPTION
## Summary
- avoid duplicate publish races by skipping the release-on-tag workflow for bot-pushed tags
- clean dist before build so publish artifacts are deterministic
- document the official stable-release-from-beta workflow in RELEASING.md
- keep local release planning docs ignored via an explicit specs/RELEASE_PLAN.md ignore entry

## Validation
- pnpm build
- pnpm lint (existing warnings)
- pnpm test:run
- pnpm typecheck
- pnpm docs:build