### PR TITLE
chore(ci): remove gitleaks secret detection

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -34,7 +34,6 @@ jobs:
               - '.github/workflows/security.yml'
               - '.coderabbit.yaml'
               - 'SECURITY.md'
-              - '.gitleaks.toml'
             config:
               - 'package.json'
               - 'tsconfig.json'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -55,21 +55,6 @@ jobs:
         with:
           config-file: './.github/dependency-review-config.yml'
 
-  # Secret scanning with Gitleaks
-  gitleaks:
-    name: Secret Detection
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-
-      - name: Gitleaks Scan
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   # OSSF Scorecard for supply chain security
   scorecard:
     name: OSSF Scorecard


### PR DESCRIPTION
## Summary
- Removes the Gitleaks secret detection job from the security scanning workflow — GitHub's built-in secret scanning already covers this
- Cleans up the `.gitleaks.toml` reference from auto-label config

## Changes
- `.github/workflows/security.yml`: removed `gitleaks` job (CodeQL, dependency review, and OSSF Scorecard remain)
- `.github/workflows/auto-label.yml`: removed `.gitleaks.toml` from security label paths

## Note
The Cloudflare Pages deploy workflow (`deploy-docs.yml` in PR #168) already triggers only on `docs/**` changes — no update needed.

## Test plan
- [ ] Verify security workflow still runs CodeQL, dependency review, and OSSF Scorecard
- [ ] Verify auto-labeling still works for security-related files

🤖 Generated with [Claude Code](https://claude.com/claude-code)