### PR TITLE
fix(release): bump version to 0.2.0 for npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-starter",
-  "version": "0.1.1-beta.16",
+  "version": "0.2.0",
   "description": "Ralph Wiggum made easy. One command to run autonomous AI coding loops with auto-commit, PRs, and Docker sandbox.",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Bumps `package.json` version from `0.1.1-beta.16` to `0.2.0`
- The v0.2.0 release commit (#171) forgot to update the version, causing the npm publish CI step to fail with `E403` (version already exists)

## Test plan
- [ ] CI passes
- [ ] npm publish succeeds with version `0.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)