### PR TITLE
fix(loop): improve validation for greenfield builds

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -83,6 +83,10 @@ program
   .option('--circuit-breaker-failures <n>', 'Max consecutive failures before stopping (default: 3)')
   .option('--circuit-breaker-errors <n>', 'Max same error occurrences before stopping (default: 5)')
   .option(
+    '--validation-warmup <n>',
+    'Skip validation until N tasks are completed (auto-detected for greenfield builds)'
+  )
+  .option(
     '--context-budget <n>',
     'Max input tokens per iteration for smart context trimming (0 = unlimited)'
   )

--- a/src/loop/__tests__/validation.test.ts
+++ b/src/loop/__tests__/validation.test.ts
@@ -89,7 +89,7 @@ describe('validation', () => {
       expect(commands.find((c) => c.name === 'test')).toEqual({
         name: 'test',
         command: 'npm',
-        args: ['run', 'test'],
+        args: ['test'],
       });
     });
 

--- a/src/loop/validation.ts
+++ b/src/loop/validation.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { execa } from 'execa';
+import { detectPackageManager, getRunCommand } from '../utils/package-manager.js';
 
 export interface ValidationCommand {
   name: string;
@@ -68,18 +69,23 @@ export function detectValidationCommands(cwd: string): ValidationCommand[] {
       try {
         const pkg = JSON.parse(readFileSync(packagePath, 'utf-8'));
         const scripts = pkg.scripts || {};
+        const pm = detectPackageManager(cwd);
 
         if (scripts.test && scripts.test !== 'echo "Error: no test specified" && exit 1') {
-          commands.push({ name: 'test', command: 'npm', args: ['run', 'test'] });
+          const cmd = getRunCommand(pm, 'test');
+          commands.push({ name: 'test', ...cmd });
         }
         if (scripts.lint) {
-          commands.push({ name: 'lint', command: 'npm', args: ['run', 'lint'] });
+          const cmd = getRunCommand(pm, 'lint');
+          commands.push({ name: 'lint', ...cmd });
         }
         if (scripts.build) {
-          commands.push({ name: 'build', command: 'npm', args: ['run', 'build'] });
+          const cmd = getRunCommand(pm, 'build');
+          commands.push({ name: 'build', ...cmd });
         }
         if (scripts.typecheck) {
-          commands.push({ name: 'typecheck', command: 'npm', args: ['run', 'typecheck'] });
+          const cmd = getRunCommand(pm, 'typecheck');
+          commands.push({ name: 'typecheck', ...cmd });
         }
       } catch {
         // Invalid package.json

--- a/src/utils/__tests__/package-manager.test.ts
+++ b/src/utils/__tests__/package-manager.test.ts
@@ -1,0 +1,94 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { detectPackageManager, formatRunCommand, getRunCommand } from '../package-manager.js';
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+const mockExistsSync = vi.mocked(existsSync);
+const mockReadFileSync = vi.mocked(readFileSync);
+
+describe('detectPackageManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return pnpm when pnpm-lock.yaml exists', () => {
+    mockExistsSync.mockImplementation((p: any) => p.toString().includes('pnpm-lock.yaml'));
+    expect(detectPackageManager('/test')).toBe('pnpm');
+  });
+
+  it('should return yarn when yarn.lock exists', () => {
+    mockExistsSync.mockImplementation((p: any) => p.toString().includes('yarn.lock'));
+    expect(detectPackageManager('/test')).toBe('yarn');
+  });
+
+  it('should return bun when bun.lockb exists', () => {
+    mockExistsSync.mockImplementation((p: any) => p.toString().includes('bun.lockb'));
+    expect(detectPackageManager('/test')).toBe('bun');
+  });
+
+  it('should return bun when bun.lock exists', () => {
+    mockExistsSync.mockImplementation((p: any) => p.toString().includes('bun.lock'));
+    expect(detectPackageManager('/test')).toBe('bun');
+  });
+
+  it('should read packageManager field from package.json', () => {
+    mockExistsSync.mockImplementation((p: any) => p.toString().includes('package.json'));
+    mockReadFileSync.mockReturnValue(JSON.stringify({ packageManager: 'pnpm@9.0.0' }));
+    expect(detectPackageManager('/test')).toBe('pnpm');
+  });
+
+  it('should prefer lockfile over packageManager field', () => {
+    mockExistsSync.mockImplementation(
+      (p: any) => p.toString().includes('yarn.lock') || p.toString().includes('package.json')
+    );
+    mockReadFileSync.mockReturnValue(JSON.stringify({ packageManager: 'pnpm@9.0.0' }));
+    expect(detectPackageManager('/test')).toBe('yarn');
+  });
+
+  it('should default to npm when no indicators found', () => {
+    mockExistsSync.mockReturnValue(false);
+    expect(detectPackageManager('/test')).toBe('npm');
+  });
+
+  it('should default to npm for unrecognized packageManager', () => {
+    mockExistsSync.mockImplementation((p: any) => p.toString().includes('package.json'));
+    mockReadFileSync.mockReturnValue(JSON.stringify({ packageManager: 'unknown@1.0.0' }));
+    expect(detectPackageManager('/test')).toBe('npm');
+  });
+
+  it('should handle invalid package.json gracefully', () => {
+    mockExistsSync.mockImplementation((p: any) => p.toString().includes('package.json'));
+    mockReadFileSync.mockReturnValue('not valid json');
+    expect(detectPackageManager('/test')).toBe('npm');
+  });
+});
+
+describe('getRunCommand', () => {
+  it('should return shorthand for test script', () => {
+    expect(getRunCommand('pnpm', 'test')).toEqual({ command: 'pnpm', args: ['test'] });
+    expect(getRunCommand('npm', 'test')).toEqual({ command: 'npm', args: ['test'] });
+    expect(getRunCommand('bun', 'test')).toEqual({ command: 'bun', args: ['test'] });
+  });
+
+  it('should use run for non-test scripts', () => {
+    expect(getRunCommand('pnpm', 'build')).toEqual({ command: 'pnpm', args: ['run', 'build'] });
+    expect(getRunCommand('npm', 'lint')).toEqual({ command: 'npm', args: ['run', 'lint'] });
+    expect(getRunCommand('bun', 'dev')).toEqual({ command: 'bun', args: ['run', 'dev'] });
+  });
+});
+
+describe('formatRunCommand', () => {
+  it('should format test commands', () => {
+    expect(formatRunCommand('pnpm', 'test')).toBe('pnpm test');
+    expect(formatRunCommand('npm', 'test')).toBe('npm test');
+  });
+
+  it('should format run commands', () => {
+    expect(formatRunCommand('pnpm', 'build')).toBe('pnpm run build');
+    expect(formatRunCommand('yarn', 'lint')).toBe('yarn run lint');
+  });
+});

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -1,0 +1,61 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun';
+
+/**
+ * Detect the package manager used in a project directory.
+ *
+ * Detection priority:
+ * 1. Lock file presence (most reliable — reflects actual usage)
+ * 2. packageManager field in package.json (explicit declaration)
+ * 3. Default: npm
+ */
+export function detectPackageManager(cwd: string): PackageManager {
+  // Check lock files first (most reliable indicator of actual usage)
+  if (existsSync(join(cwd, 'pnpm-lock.yaml'))) return 'pnpm';
+  if (existsSync(join(cwd, 'yarn.lock'))) return 'yarn';
+  if (existsSync(join(cwd, 'bun.lockb')) || existsSync(join(cwd, 'bun.lock'))) return 'bun';
+
+  // Check package.json packageManager field
+  const packageJsonPath = join(cwd, 'package.json');
+  if (existsSync(packageJsonPath)) {
+    try {
+      const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+      if (pkg.packageManager) {
+        const name = pkg.packageManager.split('@')[0];
+        if (['pnpm', 'yarn', 'bun'].includes(name)) {
+          return name as PackageManager;
+        }
+      }
+    } catch {
+      // Invalid package.json — fall through to default
+    }
+  }
+
+  return 'npm';
+}
+
+/**
+ * Get the run command for a package manager script.
+ * For 'test', uses the shorthand (e.g., `pnpm test`).
+ * For other scripts, uses `run` (e.g., `pnpm run build`).
+ */
+export function getRunCommand(
+  pm: PackageManager,
+  script: string
+): { command: string; args: string[] } {
+  if (script === 'test') {
+    return { command: pm, args: ['test'] };
+  }
+  return { command: pm, args: ['run', script] };
+}
+
+/**
+ * Format a run command as a display string.
+ * e.g., "pnpm run build" or "bun test"
+ */
+export function formatRunCommand(pm: PackageManager, script: string): string {
+  const { command, args } = getRunCommand(pm, script);
+  return `${command} ${args.join(' ')}`;
+}

--- a/src/wizard/spec-generator.ts
+++ b/src/wizard/spec-generator.ts
@@ -1,3 +1,4 @@
+import { detectPackageManager, formatRunCommand } from '../utils/package-manager.js';
 import type { TechStack, WizardAnswers } from './types.js';
 import { formatComplexity, formatProjectType } from './ui.js';
 
@@ -160,9 +161,11 @@ export function generateAgentsMd(answers: WizardAnswers): string {
     answers.techStack.backend === 'nodejs';
 
   if (hasNodeStack) {
-    sections.push('- **lint**: `npm run lint`');
-    sections.push('- **build**: `npm run build`');
-    sections.push('- **test**: `npm test`');
+    // Detect PM from working directory if available, default to npm for greenfield projects
+    const pm = answers.workingDirectory ? detectPackageManager(answers.workingDirectory) : 'npm';
+    sections.push(`- **lint**: \`${formatRunCommand(pm, 'lint')}\``);
+    sections.push(`- **build**: \`${formatRunCommand(pm, 'build')}\``);
+    sections.push(`- **test**: \`${formatRunCommand(pm, 'test')}\``);
   } else if (answers.techStack.backend === 'python') {
     sections.push('- **lint**: `ruff check .`');
     sections.push('- **test**: `pytest`');


### PR DESCRIPTION
## Summary

Fixes loop failures when building new projects from scratch (e.g., "build a React todo app"). Three root causes addressed:

- **Circuit breaker trips too early**: The breaker counted consecutive validation failures across task boundaries. Now resets when a task completes (forward progress signal)
- **Package manager hardcoded to npm**: All validation/init/wizard code assumed `npm`. Now auto-detects pnpm/yarn/bun from lockfiles and `packageManager` field
- **No warm-up period**: Validation ran on every iteration, even Task 1 "Project Setup" where tests can't possibly pass. Now auto-skips validation for first ~50% of tasks on greenfield builds (configurable via `--validation-warmup`)

## Changes

- `src/loop/executor.ts` — Circuit breaker reset on task advancement + validation warm-up guard
- `src/loop/validation.ts` — Use detected package manager in fallback path
- `src/commands/init.ts` — Use detected PM in project detection + AGENTS.md generation
- `src/commands/run.ts` — Use detected PM for dev commands + auto-detect greenfield warm-up
- `src/wizard/spec-generator.ts` — Use detected PM for generated validation commands
- `src/cli.ts` — Add `--validation-warmup` CLI flag
- `src/utils/package-manager.ts` — **NEW** package manager detection utility
- `src/utils/__tests__/package-manager.test.ts` — **NEW** 13 tests for PM detection

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test:run` passes (156 tests, 13 new)
- [ ] Manual test: run ralph-starter with `--validate` on a greenfield project


🤖 Generated with [Claude Code](https://claude.com/claude-code)