### PR TITLE
feat(loop): Ralph Playbook prompt engineering for loop context

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -455,7 +455,7 @@ export async function runCommand(
       writeFileSync(implementationPlanPath, extractedPlan);
       console.log(chalk.cyan('Created IMPLEMENTATION_PLAN.md from spec'));
 
-      finalTask = `Build the following project based on this specification:
+      finalTask = `Study the following specification carefully:
 
 ${sourceSpec}
 
@@ -463,13 +463,33 @@ ${sourceSpec}
 
 An IMPLEMENTATION_PLAN.md file has been created with tasks extracted from this spec.
 As you complete each task, mark it done by changing [ ] to [x] in IMPLEMENTATION_PLAN.md.
-Focus on one task at a time.`;
+Focus on ONE task at a time. Don't assume functionality is not already implemented — search the codebase first.
+Implement completely — no placeholders or stubs.`;
     } else {
-      finalTask = `Build the following project based on this specification:
+      finalTask = `Study the following specification carefully:
 
 ${sourceSpec}
 
-Analyze the specification and implement all required features. Create a proper project structure with all necessary files.`;
+## Getting Started
+
+IMPORTANT: Before writing any code, you MUST first:
+1. Study the specification above thoroughly
+2. Search the codebase — don't assume functionality is not already implemented
+3. Create an IMPLEMENTATION_PLAN.md file with tasks broken down as:
+
+### Task 1: [name]
+- [ ] Subtask a
+- [ ] Subtask b
+
+### Task 2: [name]
+- [ ] Subtask a
+
+Break the spec into 3-8 logical tasks, sorted by priority.
+
+4. Then start working on Task 1 only.
+
+As you complete each subtask, mark it done by changing [ ] to [x] in IMPLEMENTATION_PLAN.md.
+Focus on ONE task at a time. Implement completely — no placeholders or stubs.`;
     }
     console.log(chalk.cyan('Using fetched specification as task'));
   }


### PR DESCRIPTION
## Summary
- Add loop-aware preamble to every agent iteration using key Ralph Playbook language patterns ("study", "don't assume not implemented", "no placeholders or stubs", AGENTS.md self-improvement)
- For unstructured specs without task headers, instruct agent to create `IMPLEMENTATION_PLAN.md` as its first action — instead of generic "implement all features" prompt
- Add `specs/` directory references in iterations 2+ to prevent context degradation (agent losing requirements)

## What changed

### Context Builder (`src/loop/context-builder.ts`)
Every iteration now starts with a behavioral preamble (~120 tokens) that gives the agent critical loop awareness:
```
You are a coding agent in an autonomous development loop (iteration N/M).

Rules:
- Study IMPLEMENTATION_PLAN.md and work on ONE task at a time
- Don't assume functionality is not already implemented — search the codebase first
- Implement completely — no placeholders or stubs
- When ALL tasks are complete, explicitly state "All tasks completed"
- If you learn how to run/build the project, update AGENTS.md
```

Iterations 2+ now reference `specs/` directory so the agent can re-read original requirements.

### Run Command (`src/commands/run.ts`)
When `extractTasksFromSpec()` returns null (no `### Task N:` headers or checkboxes in spec), the prompt now instructs the agent to create a structured `IMPLEMENTATION_PLAN.md` before coding — following the Ralph Wiggum pattern of always working from a plan file.

## Test plan
- [x] `pnpm build` compiles
- [x] `pnpm test` — all 143 tests pass
- [ ] Manual: `ralph-starter run --from github --issue 86` — verify agent creates IMPLEMENTATION_PLAN.md
- [ ] Manual: verify `RALPH_DEBUG=1` shows preamble in iteration context

🤖 Generated with [Claude Code](https://claude.com/claude-code)