### PR TITLE
fix(loop): remove iteration delay and fix validation feedback mutation

### DIFF
--- a/src/loop/executor.ts
+++ b/src/loop/executor.ts
@@ -23,7 +23,7 @@ import {
 } from '../utils/rate-limit-display.js';
 import { type Agent, type AgentRunOptions, runAgent } from './agents.js';
 import { CircuitBreaker, type CircuitBreakerConfig } from './circuit-breaker.js';
-import { buildIterationContext, compressValidationFeedback } from './context-builder.js';
+import { buildIterationContext } from './context-builder.js';
 import { CostTracker, type CostTrackerStats, formatCost } from './cost-tracker.js';
 import { estimateLoop, formatEstimateDetailed } from './estimator.js';
 import { checkFileBasedCompletion, createProgressTracker, type ProgressEntry } from './progress.js';
@@ -430,6 +430,9 @@ export async function runLoop(options: LoopOptions): Promise<LoopResult> {
     taskWithSkills = `${options.task}\n\n${skillsPrompt}`;
   }
 
+  // Track validation feedback separately — don't mutate taskWithSkills
+  let lastValidationFeedback = '';
+
   // Completion detection options
   const completionOptions: CompletionOptions = {
     completionPromise: options.completionPromise,
@@ -623,7 +626,7 @@ export async function runLoop(options: LoopOptions): Promise<LoopResult> {
       taskInfo,
       iteration: i,
       maxIterations,
-      validationFeedback: undefined, // Validation feedback handled separately below
+      validationFeedback: lastValidationFeedback || undefined,
       maxInputTokens: options.contextBudget || 0,
     });
     const iterationTask = builtContext.prompt;
@@ -863,14 +866,15 @@ export async function runLoop(options: LoopOptions): Promise<LoopResult> {
           await progressTracker.appendEntry(progressEntry);
         }
 
-        // Continue loop with compressed validation feedback
-        const compressedFeedback = compressValidationFeedback(feedback);
-        taskWithSkills = `${taskWithSkills}\n\n${compressedFeedback}`;
+        // Pass validation feedback to context builder for next iteration
+        // (don't mutate taskWithSkills — that defeats context trimming)
+        lastValidationFeedback = feedback;
         continue; // Go to next iteration to fix issues
       } else {
-        // Validation passed - record success
+        // Validation passed - record success and clear feedback
         spinner.succeed(chalk.green(`Loop ${i}: Validation passed`));
         circuitBreaker.recordSuccess();
+        lastValidationFeedback = '';
       }
     }
 
@@ -960,9 +964,6 @@ export async function runLoop(options: LoopOptions): Promise<LoopResult> {
         `Iter ${i}/${maxIterations}${taskLabel}${costLabel} │ ${elapsedMin}m ${elapsedSec}s`
       )
     );
-
-    // Small delay between iterations
-    await new Promise((resolve) => setTimeout(resolve, 1000));
   }
 
   // Post-loop actions


### PR DESCRIPTION
## Summary
- Remove 1-second sleep between loop iterations (saves ~1s per iteration)
- Fix validation feedback mutation bug that defeated context trimming
- Wire up the `validationFeedback` parameter in context builder (was dead code)

## Changes

### Remove Iteration Delay (`src/loop/executor.ts`)
Deleted `await new Promise((resolve) => setTimeout(resolve, 1000))` — an unconditional 1-second sleep between every iteration. On a 25-iteration loop, this wastes 25 seconds doing nothing. Agent process spawning provides natural pacing.

### Fix Validation Feedback Mutation (`src/loop/executor.ts`)
**Bug:** When validation fails, the executor was doing:
```typescript
taskWithSkills = `${taskWithSkills}\n\n${compressedFeedback}`;
```
This **mutates the base prompt**, accumulating old validation errors across iterations. After 3 failed validations, the prompt contains 3 layered error outputs, defeating the progressive context trimming strategy in `context-builder.ts`.

**Fix:** Store feedback in a separate `lastValidationFeedback` variable and pass it through the context builder's existing `validationFeedback` parameter — which was previously passed as `undefined` (dead code). The context builder already has per-iteration compression logic: 2000 chars for iterations 2-3, 500 chars for iterations 4+.

## Test plan
- [x] `pnpm build` compiles
- [x] `pnpm test` — all 143 tests pass
- [ ] Manual: verify no pause between iterations
- [ ] `RALPH_DEBUG=1`: verify validation feedback appears via context builder, not appended to taskWithSkills

🤖 Generated with [Claude Code](https://claude.com/claude-code)