### PR TITLE
chore(release): v0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-starter",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Ralph Wiggum made easy. One command to run autonomous AI coding loops with auto-commit, PRs, and Docker sandbox.",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump version to 0.3.2 for npm publish
- v0.3.1 was already published, so the fix from #205 needs a new version to ship

## Changes
- `package.json`: version 0.3.1 → 0.3.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)